### PR TITLE
chromedriver was migrated from homebrew/core to homebrew/cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ See our [example tests](tests/).
 Install Selenium:
 
 ```bash
-brew install selenium-server-standalone chromedriver geckodriver
+brew tap homebrew/cask
+brew cask install chromedriver
+brew install selenium-server-standalone geckodriver
 ```
 
 Start the Selenium server:


### PR DESCRIPTION
```
➜  e2e git:(update-docs) ✗ brew install chromedriver
Error: No available formula with the name "chromedriver"
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install chromedriver
```