### PR TITLE
Added puppeteer.launch option: --disable-dev-shm-usage

### DIFF
--- a/lib/run-test.js
+++ b/lib/run-test.js
@@ -201,6 +201,7 @@ module.exports = class RunTest {
       fn: async () => {
         const browser = await puppeteer.launch({
           headless: mode === 'headless',
+          args: ['--disable-dev-shm-usage'],
         })
         const page = await browser.newPage()
         await page.setViewport({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/e2e",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Make End-to-End Testing Great for Once",
   "main": "lib",
   "scripts": {


### PR DESCRIPTION
[Based on the puppeteer Troubleshooting page](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips) and a [GitHub Issue](https://github.com/GoogleChrome/puppeteer/issues/1175) documenting an error we're only seeing in CI, this disallows memory limitations in Docker containers which can have an unintended side-effect of crashing the testing suite.