### PR TITLE
[version] patch version bump; pin puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/e2e",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Make End-to-End Testing Great for Once",
   "main": "lib",
   "scripts": {
@@ -41,7 +41,7 @@
     "lodash": "4.17.5",
     "ms": "2.0.0",
     "p-all": "1.0.0",
-    "puppeteer": "^1.11.0",
+    "puppeteer": "1.11.0",
     "saucelabs": "1.4.0",
     "selenium-webdriver": "3.6.0"
   },


### PR DESCRIPTION
## Update

Pins puppeteer. 

Puppeteer is one of a few deps e2e needs. Puppeteer consistently releases updates that break e2es.
This PR pins puppeteer to its last working version for us.  