### PR TITLE
Get Dockerfile to working condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,26 @@ ENV NPM_CONFIG_LOGLEVEL error
 # https://gist.github.com/ralphtheninja/f7c45bdee00784b41fed
 ENV JOBS max
 
-RUN mkdir -p /app
-WORKDIR /app
-COPY . /app
+ENV WORKDIR /app
+WORKDIR $WORKDIR
 
+# Point node to where the modules are for custom tests location
+ENV NODE_PATH $WORKDIR/node_modules
+
+# Copy in package/lock explicitly to allow caching of modules
+COPY package.json $WORKDIR
+COPY package-lock.json $WORKDIR
 RUN npm install --production
+
+COPY . $WORKDIR
 
 USER circleci
 
-ENTRYPOINT [ "node", "./bin/run.js" ]
+# start xvfb automatically, local-only access
+ENV DISPLAY :99
+RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &\nexec node ./bin/run.js "$@"\n' > /tmp/entrypoint \
+  && chmod +x /tmp/entrypoint \
+  && sudo mv /tmp/entrypoint /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "tests/**/*.js" ]


### PR DESCRIPTION
**Why**
Needed the following:
- Xvfb started for selenium tests

Optimizations:
- running Xvfb without tcp/socket listen and access control disabled
since it's local only to avoid seeing an error message related to socket
- explicit copy of package/lock to leverage docker caching / avoid
module reinstall in case only app code changed
- point NODE_PATH to where the modules are so that you can run the docker
with arbitrary test location like this:
`docker run -it -v $(PWD)/tests:/mytests e2e:latest /mytests/**/*.js`

**Testing**
1) Dockerfile builds
2) This passing: `docker run -it e2e:latest`
3) This passing: `docker run -it -v $(PWD)/tests:/mytests e2e:latest /mytests/**/*.js`